### PR TITLE
Use searchsorted instead of digitize

### DIFF
--- a/DSTK/FeatureBinning/base_binner.py
+++ b/DSTK/FeatureBinning/base_binner.py
@@ -69,7 +69,10 @@ class BaseBinner(object):
             warnings.warn("Bin edge already exists.", UserWarning)
             return self
 
-        idx = np.digitize(right_bin_edge, self.splits, right=True)
+        # use np.searchsorted instead of digitize as the latter
+        # gives the wrong result for purely non-numeric splits
+        # see corresponding test for the issue
+        idx = np.searchsorted(self.splits, right_bin_edge, side='right')
         self.splits = np.insert(self.splits, idx, right_bin_edge).tolist()
         self.values = np.insert(self.values, [idx], bin_value, axis=0).tolist()
 

--- a/DSTK/tests/test_feature_binner/test_conditional_inference_binner.py
+++ b/DSTK/tests/test_feature_binner/test_conditional_inference_binner.py
@@ -63,6 +63,17 @@ def test_adding_bin():
                              [0.37258347978910367, 0.62741652021089633]])
 
 
+def test_adding_bin_with_non_numeric_splits_only():
+    cib = ConditionalInferenceBinner('test', alpha=0.05)
+    cib.splits = [np.PINF, np.NaN]
+    cib.values = [[0.1, 0.9], [0.8, 0.2]]
+    cib.is_fit = True
+
+    cib.add_bin(-1.0, [0.3, 0.7])
+    np.testing.assert_equal(cib.splits, [-1.0, np.PINF, np.NaN])
+    np.testing.assert_equal(cib.values, [[0.3, 0.7], [0.1, 0.9], [0.8, 0.2]])
+
+
 def test_recursion_with_nan():
     col = 'mean area'
     data = cancer_df[col].values


### PR DESCRIPTION
to ensure proper insertion in case on non-numeric splits